### PR TITLE
Send a custom exception to throw in case of required env/property to get

### DIFF
--- a/envutils4j/src/main/java/org/adorsys/envutils/EnvProperties.java
+++ b/envutils4j/src/main/java/org/adorsys/envutils/EnvProperties.java
@@ -6,11 +6,23 @@ public class EnvProperties {
 	public static String getEnvOrSysProp(String propName, boolean optional) {
 		String propValue = System.getenv(propName);
 
-		if(StringUtils.isBlank(propValue))propValue = System.getProperty(propName);
+		if(StringUtils.isBlank(propValue)) propValue = System.getProperty(propName);
 		
 		if(StringUtils.isBlank(propValue)) {
 			if (optional)return null;
 			throw new IllegalStateException("Missing Environmen property " + propName);
+		}
+		return propValue;
+	}
+
+	public static String getEnvOrSysProp(String propName, boolean optional, RuntimeException e) {
+		String propValue = System.getenv(propName);
+
+		if(StringUtils.isBlank(propValue))propValue = System.getProperty(propName);
+
+		if(StringUtils.isBlank(propValue)) {
+			if (optional || e == null) return null;
+			throw e;
 		}
 		return propValue;
 	}

--- a/envutils4j/src/main/java/org/adorsys/envutils/EnvProperties.java
+++ b/envutils4j/src/main/java/org/adorsys/envutils/EnvProperties.java
@@ -21,8 +21,11 @@ public class EnvProperties {
 		if(StringUtils.isBlank(propValue))propValue = System.getProperty(propName);
 
 		if(StringUtils.isBlank(propValue)) {
-			if (optional || e == null) return null;
-			throw e;
+			if (optional) return null;
+			if(e == null)
+                throw new IllegalStateException("Missing Environmen property " + propName);
+			else
+			    throw e;
 		}
 		return propValue;
 	}


### PR DESCRIPTION
**Context**:
I wanted to use this utility into a Jhipster App, but when throwing exception sometimes better is to provide a more decorated one to be able to translate it later in order to convey better error message.

**Resources**:
- [rfc7807](https://tools.ietf.org/html/rfc7807)
- [https://github.com/zalando/problem](https://github.com/zalando/problem)

**Usage**:
My Exception:
```
public class DontKnowException extends AbstractThrowableProblem {

    public DontKnowException(String message) {
        super(ErrorConstants.ERROR_CODE, message, Status.BAD_REQUEST);
    }
}
```

Call:
```
EnvProperties.getEnvOrSysProp("MY_ENV", false, new DontKnowException("Message goes here"));
```